### PR TITLE
fix: Only update abstract instances in game worlds

### DIFF
--- a/CustomImplementations/Buildables/FGBuildable.cpp
+++ b/CustomImplementations/Buildables/FGBuildable.cpp
@@ -26,9 +26,13 @@ void AFGBuildable::OnConstruction(const FTransform& transform) {
     Super::OnConstruction(transform);
 
 #if WITH_EDITOR
-    RemoveInstances();
-    RemoveInstances_Native();
-    CallSetupInstances();
+    const UWorld* World = GetWorld();
+    if (IsValid(World) and World->IsGameWorld()) {
+        // Don't do this for non-game worlds, otherwise the editor crashes when compiling a blueprint
+        RemoveInstances();
+        RemoveInstances_Native();
+        CallSetupInstances();
+    }
 #endif
 }
 TArray<struct FInstanceData> AFGBuildable::GetActorLightweightInstanceData_Implementation() {


### PR DESCRIPTION
When trying to set up abstract instances, compiling the blueprint makes the editor crash. According to Ben from CSS, the abstract instance code in question should not run during compile. So, only update the abstract instances in game worlds.