### PR TITLE
fix: Make colored instance mesh proxies visible in PIE

### DIFF
--- a/CustomImplementations/FGColoredInstanceMeshProxy.cpp
+++ b/CustomImplementations/FGColoredInstanceMeshProxy.cpp
@@ -1,6 +1,6 @@
 bool UFGColoredInstanceMeshProxy::ShouldCreateRenderState() const {
-#if WITH_EDITOR // Ensure visibility in blueprint & editor.
-    if (GetWorld()->WorldType == EWorldType::Editor || GetWorld()->WorldType == EWorldType::EditorPreview) {
+#if WITH_EDITOR // Ensure visibility in blueprint, editor & PIE
+    if (GetWorld()->IsEditorWorld()) {
         return true;
     }
 #endif


### PR DESCRIPTION
The code already accounted for two editor use-cases, but was missing the PIE use-case. Replace the checks with `IsEditorWorld` as it's equivalent to having three discrete checks.